### PR TITLE
feat: add a low default sample ratio

### DIFF
--- a/src/main/kotlin/com/monta/otel/extension/Customizer.java
+++ b/src/main/kotlin/com/monta/otel/extension/Customizer.java
@@ -60,7 +60,7 @@ public class Customizer implements AutoConfigurationCustomizerProvider {
                 return Sampler.alwaysOff();
             }
         } else {
-            return Sampler.alwaysOn();
+            return Sampler.traceIdRatioBased(0.001);
         }
     }
 }

--- a/src/main/kotlin/com/monta/otel/extension/Customizer.java
+++ b/src/main/kotlin/com/monta/otel/extension/Customizer.java
@@ -10,6 +10,7 @@ import io.opentelemetry.semconv.ResourceAttributes;
 import io.opentelemetry.semconv.ServiceAttributes;
 import io.opentelemetry.semconv.UrlAttributes;
 
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -60,7 +61,8 @@ public class Customizer implements AutoConfigurationCustomizerProvider {
                 return Sampler.alwaysOff();
             }
         } else {
-            return Sampler.traceIdRatioBased(0.001);
+            double rate = Objects.equals(System.getenv("STAGE"), "production") ? 0.1 : 1.0;
+            return Sampler.traceIdRatioBased(rate);
         }
     }
 }


### PR DESCRIPTION
# Description
Right now, the lack of `OTEL_TRACES_SAMPLER_ARG` defaults to `alwaysOn` which can create a lot of _unnecessary_ traffic for services if they miss the configuration. With this PR it will sample 1 / 1.000 requests instead

Let's start with a low sample rate and have to increase it to get more insights than start high and have to decrease the rate because we're having problems.

In the meantime, I'll also update the [respective Notion page regardless](https://www.notion.so/montaapp/Tracing-Setup-Guide-572f3d6cd4e1474dad31802d87059f8e?pvs=4)