### PR TITLE
chore: CI workflow improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'corretto'
           cache: 'gradle'
-      - name: Check
-        run: ./gradlew --no-daemon check
-      - name: Build
-        run: ./gradlew --no-daemon build
-      - name: Shadow JAR
-        run: ./gradlew --no-daemon shadowJar
+      - name: Check & build
+        run: ./gradlew --no-daemon check shadowJar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 permissions:
   contents: write
@@ -23,8 +23,6 @@ jobs:
           cache: 'gradle'
       - name: Build jar
         run: ./gradlew --no-daemon shadowJar
-      - name: Build jar
-        run: ls -a
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:


### PR DESCRIPTION
## Summary
- Remove leftover debug `ls -a` step from publish workflow
- Narrow tag trigger from `*` to `v*`
- Combine 3 CI Gradle invocations into single `check shadowJar`
- Update CI to JDK 25 (matching `jvmToolchain(25)` on main)

## Test plan
- [ ] CI runs on this PR