### PR TITLE
feat(sampler): add forced tracing via custom request header [SRE-198]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,0 @@
-[*.{kt,kts}]
-indent_style = space
-indent_size = 4
-ij_any_if_brace_force = always
-ktlint_code_style = intellij_idea
-ktlint_disabled_rules = no-wildcard-imports, enum-entry-name-case
-ij_kotlin_allow_trailing_comma_on_call_site = false
-ij_kotlin_allow_trailing_comma = false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is an OpenTelemetry SDK extension that provides custom sampling and resource configuration. The extension automatically configures OpenTelemetry instrumentation with environment-specific settings and intelligent sampling rules.
+
+## Build Commands
+
+- `./gradlew build` - Build the project and run all checks
+- `./gradlew shadowJar` - Create a fat JAR for distribution (output: `build/libs/otel-extension.jar`)
+- `./gradlew ktlintCheck` - Run Kotlin linting checks
+- `./gradlew ktlintFormat` - Auto-format code according to ktlint rules
+- `./gradlew clean` - Clean build artifacts
+
+## Usage
+
+Example of how to run with the otel agent:
+```
+JAVA_TOOL_OPTIONS: -javaagent:/home/app/opentelemetry-javaagent.jar -Dotel.javaagent.extensions=/home/app/otel-extension.jar
+```
+
+## Architecture
+
+### SPI Extension Pattern
+The project uses Java's Service Provider Interface (SPI) for automatic discovery:
+- `Customizer.java` implements `AutoConfigurationCustomizerProvider`
+- Registered in `src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider`
+- OpenTelemetry SDK automatically discovers and loads this extension
+
+### Custom Resource Configuration
+The extension adds these resource attributes from environment variables:
+- `service.instance.id` - Random UUID generated at startup
+- `service.name` - From `SERVICE_NAME` environment variable
+- `deployment.environment.name` - From `STAGE` environment variable  
+- `service.version` - From `BUILD_NUMBER` environment variable
+
+### Intelligent Sampling Strategy
+- **Base Sampler**: Parent-based sampling with custom routing rules
+- **Dropped Endpoints**: Health checks (`/health*`), metrics (`/prometheus*`, `/metrics*`)
+- **Environment-based Rates**:
+  - Production (`STAGE=production`): 10% sampling rate
+  - Non-production: 100% sampling rate
+  - Override with `OTEL_TRACES_SAMPLER_ARG` environment variable
+- **Endpoint Dropping Configuration**:
+  - Configure endpoints to be dropped via the `OTEL_INSTRUMENTATION_HTTP_SERVER_EXCLUDED_URL_PATHS` environment variable.
+  - The value should be a comma-separated list of paths (e.g., `/health*,/metrics*`).
+  - Defaults to `/health*,/prometheus*,/metrics*` if not set.
+- **Forced Tracing via Request Header**:
+  - Enable with `OTEL_FORCE_TRACE_HEADER_ENABLED=true` (default: disabled).
+  - When enabled, any request containing the `Force-Trace: true` (or `1`) header is always sampled, bypassing all other sampling rules.
+  - The header is automatically configured for capture as a span attribute.
+
+### Key Dependencies
+- OpenTelemetry SDK 2.17.0 with instrumentation BOM
+- OpenTelemetry Contrib Samplers for rule-based routing
+- Shadow plugin for creating distributable JAR
+
+## File Structure
+
+- `src/main/java/com/monta/otel/extension/Customizer.java` - Main extension implementation
+- `src/main/java/com/monta/otel/extension/ForcedTracingSampler.java` - Forced tracing via request header
+- `src/main/java/com/monta/otel/extension/ResponseHeaderCustomizer.java` - Trace ID response header injection
+- `src/main/resources/META-INF/services/` - SPI service registration
+- `build.gradle.kts` - Gradle build configuration with shadow JAR setup
+- `gradle.properties` - JVM settings for builds (4GB heap)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,6 @@ This is an OpenTelemetry SDK extension that provides custom sampling and resourc
 
 - `./gradlew build` - Build the project and run all checks
 - `./gradlew shadowJar` - Create a fat JAR for distribution (output: `build/libs/otel-extension.jar`)
-- `./gradlew ktlintCheck` - Run Kotlin linting checks
-- `./gradlew ktlintFormat` - Auto-format code according to ktlint rules
 - `./gradlew clean` - Clean build artifacts
 
 ## Usage
@@ -49,7 +47,7 @@ The extension adds these resource attributes from environment variables:
   - Defaults to `/health*,/prometheus*,/metrics*` if not set.
 - **Forced Tracing via Request Header**:
   - Enable with `OTEL_FORCE_TRACE_HEADER_ENABLED=true` (default: disabled).
-  - When enabled, any request containing the `Force-Trace: true` (or `1`) header is always sampled, bypassing all other sampling rules.
+  - When enabled, any request containing the `Force-Trace: true` header is always sampled, bypassing all other sampling rules.
   - The header is automatically configured for capture as a span attribute.
 
 ### Key Dependencies

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Trace-Id: 4bf92f3577b34da6a3ce929d0e0e4736
 The extension can force a specific request to always be sampled, regardless of the configured sampling rate or environment.
 
 **Header:**
-- `Force-Trace: true` (also accepts `1`)
+- `Force-Trace: true`
 
 **Configuration:**
 Set `OTEL_FORCE_TRACE_HEADER_ENABLED=true` to enable forced tracing.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The extension can be configured using the following environment variables:
 | `OTEL_TRACES_SAMPLER_ARG`        | The sampling rate to use. Overrides the default sampling rate.                                                                            | `0.1` (prod), `1.0` (non-prod) |
 | `OTEL_TRACES_EXCLUDED_URL_PATHS` | A comma-separated list of URL paths to exclude from tracing (e.g., `/health*,/metrics*`).                                                | `/health*,/prometheus*,/metrics*` |
 | `OTEL_RESPONSE_HEADERS_ENABLED`  | Set to `true` to enable trace ID injection in response headers.                                                                           | `false` |
+| `OTEL_FORCE_TRACE_HEADER_ENABLED` | Set to `true` to enable forced tracing via the `Force-Trace` request header.                                                             | `false` |
 
 ## Features
 
@@ -37,3 +38,22 @@ Trace-Id: 4bf92f3577b34da6a3ce929d0e0e4736
 - Correlation between frontend and backend traces
 - Simplified debugging of distributed systems
 - Customer support troubleshooting
+
+### Forced Tracing via Request Header
+
+The extension can force a specific request to always be sampled, regardless of the configured sampling rate or environment.
+
+**Header:**
+- `Force-Trace: true` (also accepts `1`)
+
+**Configuration:**
+Set `OTEL_FORCE_TRACE_HEADER_ENABLED=true` to enable forced tracing.
+
+**Example Request Headers:**
+```
+Force-Trace: true
+```
+
+**Use Cases:**
+- Debugging specific requests in production without changing the sampling rate
+- Integration testing against live environments

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,15 +20,19 @@ dependencies {
     implementation("io.opentelemetry.contrib:opentelemetry-samplers:1.54.0-alpha")
     // Dependency for HTTP response header customization
     implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 sourceSets {
     main {
-        java.srcDirs("src/main/kotlin")
+        java.srcDirs("src/main/java")
         resources.srcDirs("src/main/resources")
     }
     test {
-        java.srcDirs("src/test/kotlin")
+        java.srcDirs("src/test/java")
         resources.srcDirs("src/test/resources")
     }
 }
@@ -40,11 +44,14 @@ kotlin {
 ktlint {
     filter {
         exclude("**/generated/**")
-        include("**/kotlin/**")
+        include("**/java/**")
     }
 }
 
 tasks {
+    test {
+        useJUnitPlatform()
+    }
     shadowJar {
         archiveBaseName.set("otel-extension")
         archiveVersion.set("")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
-    kotlin("jvm") version "2.3.21"
+    java
     id("com.gradleup.shadow") version "9.4.1"
-    id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 }
 
 version = "1.0.0"
@@ -26,25 +25,9 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
-sourceSets {
-    main {
-        java.srcDirs("src/main/java")
-        resources.srcDirs("src/main/resources")
-    }
-    test {
-        java.srcDirs("src/test/java")
-        resources.srcDirs("src/test/resources")
-    }
-}
-
-kotlin {
-    jvmToolchain(25)
-}
-
-ktlint {
-    filter {
-        exclude("**/generated/**")
-        include("**/java/**")
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/src/main/java/com/monta/otel/extension/Customizer.java
+++ b/src/main/java/com/monta/otel/extension/Customizer.java
@@ -12,9 +12,11 @@ import io.opentelemetry.semconv.ServiceAttributes;
 import io.opentelemetry.semconv.UrlAttributes;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+
 
 /**
  * Note this class is wired into SPI via {@code
@@ -24,6 +26,7 @@ public class Customizer implements AutoConfigurationCustomizerProvider {
 
     private static final String OTEL_TRACES_EXCLUDED_URL_PATHS_ENV_VAR = "OTEL_TRACES_EXCLUDED_URL_PATHS";
     private static final String DEFAULT_EXCLUDED_URL_PATHS = "/health*,/prometheus*,/metrics*";
+    private static final String OTEL_HTTP_SERVER_CAPTURED_REQUEST_HEADERS = "otel.instrumentation.http.server.request.captured.headers";
 
     @Override
     public void customize(AutoConfigurationCustomizer autoConfiguration) {
@@ -43,6 +46,10 @@ public class Customizer implements AutoConfigurationCustomizerProvider {
         autoConfiguration.addTracerProviderCustomizer((builder, config) ->
                 configureSampler(builder)
         );
+
+        autoConfiguration.addPropertiesSupplier(() ->
+                Map.of(OTEL_HTTP_SERVER_CAPTURED_REQUEST_HEADERS, ForcedTracingSampler.FORCE_TRACE_HEADER)
+        );
     }
 
     /**
@@ -59,7 +66,7 @@ public class Customizer implements AutoConfigurationCustomizerProvider {
                 .filter(path -> !path.isEmpty())
                 .forEach(path -> samplerBuilder.drop(UrlAttributes.URL_PATH, path));
 
-        return builder.setSampler(Sampler.parentBased(samplerBuilder.build()));
+        return builder.setSampler(new ForcedTracingSampler(Sampler.parentBased(samplerBuilder.build())));
     }
 
     private static Sampler getSampler() {

--- a/src/main/java/com/monta/otel/extension/Customizer.java
+++ b/src/main/java/com/monta/otel/extension/Customizer.java
@@ -47,15 +47,9 @@ public class Customizer implements AutoConfigurationCustomizerProvider {
                 configureSampler(builder)
         );
 
-        // Append Force-Trace to any existing captured headers (addPropertiesCustomizer reads
-        // the resolved config, so it sees env vars and other suppliers before us).
-        autoConfiguration.addPropertiesCustomizer(config -> {
-            String existing = config.getString(OTEL_HTTP_SERVER_CAPTURED_REQUEST_HEADERS);
-            String value = (existing == null || existing.isBlank())
-                    ? ForcedTracingSampler.FORCE_TRACE_HEADER
-                    : existing + "," + ForcedTracingSampler.FORCE_TRACE_HEADER;
-            return Map.of(OTEL_HTTP_SERVER_CAPTURED_REQUEST_HEADERS, value);
-        });
+        autoConfiguration.addPropertiesSupplier(() ->
+                Map.of(OTEL_HTTP_SERVER_CAPTURED_REQUEST_HEADERS, ForcedTracingSampler.FORCE_TRACE_HEADER)
+        );
     }
 
     /**

--- a/src/main/java/com/monta/otel/extension/Customizer.java
+++ b/src/main/java/com/monta/otel/extension/Customizer.java
@@ -47,9 +47,15 @@ public class Customizer implements AutoConfigurationCustomizerProvider {
                 configureSampler(builder)
         );
 
-        autoConfiguration.addPropertiesSupplier(() ->
-                Map.of(OTEL_HTTP_SERVER_CAPTURED_REQUEST_HEADERS, ForcedTracingSampler.FORCE_TRACE_HEADER)
-        );
+        // Append Force-Trace to any existing captured headers (addPropertiesCustomizer reads
+        // the resolved config, so it sees env vars and other suppliers before us).
+        autoConfiguration.addPropertiesCustomizer(config -> {
+            String existing = config.getString(OTEL_HTTP_SERVER_CAPTURED_REQUEST_HEADERS);
+            String value = (existing == null || existing.isBlank())
+                    ? ForcedTracingSampler.FORCE_TRACE_HEADER
+                    : existing + "," + ForcedTracingSampler.FORCE_TRACE_HEADER;
+            return Map.of(OTEL_HTTP_SERVER_CAPTURED_REQUEST_HEADERS, value);
+        });
     }
 
     /**

--- a/src/main/java/com/monta/otel/extension/ForcedTracingSampler.java
+++ b/src/main/java/com/monta/otel/extension/ForcedTracingSampler.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 /**
  * A sampler that forces recording and sampling when the {@code Force-Trace} request header
- * is present with a value of {@code "true"} or {@code "1"}.
+ * is present with a value of {@code "true"} (case-insensitive).
  * <p>
  * When triggered, the span is always sampled regardless of the delegate sampler's decision.
  * Otherwise, sampling falls through to the delegate.

--- a/src/main/java/com/monta/otel/extension/ForcedTracingSampler.java
+++ b/src/main/java/com/monta/otel/extension/ForcedTracingSampler.java
@@ -1,0 +1,67 @@
+package com.monta.otel.extension;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+
+import java.util.List;
+
+/**
+ * A sampler that forces recording and sampling when the {@code Force-Trace} request header
+ * is present with a value of {@code "true"} or {@code "1"}.
+ * <p>
+ * When triggered, the span is always sampled regardless of the delegate sampler's decision.
+ * Otherwise, sampling falls through to the delegate.
+ * <p>
+ * Configuration:
+ * - OTEL_FORCE_TRACE_HEADER_ENABLED: Set to "true" to enable forced tracing (default: disabled)
+ */
+public class ForcedTracingSampler implements Sampler {
+
+    static final String FORCE_TRACE_HEADER = "Force-Trace";
+    private static final String ENABLED_ENV_VAR = "OTEL_FORCE_TRACE_HEADER_ENABLED";
+
+    static final AttributeKey<List<String>> HEADER_ATTRIBUTE_KEY =
+            AttributeKey.stringArrayKey("http.request.header." + FORCE_TRACE_HEADER.toLowerCase());
+
+    private final Sampler delegate;
+    private final boolean enabled;
+
+    public ForcedTracingSampler(Sampler delegate) {
+        this(delegate, Boolean.parseBoolean(System.getenv(ENABLED_ENV_VAR)));
+    }
+
+    // Package-private constructor for testing
+    ForcedTracingSampler(Sampler delegate, boolean enabled) {
+        this.delegate = delegate;
+        this.enabled = enabled;
+    }
+
+    @Override
+    public SamplingResult shouldSample(
+            Context parentContext,
+            String traceId,
+            String name,
+            SpanKind spanKind,
+            Attributes attributes,
+            List<LinkData> parentLinks) {
+
+        if (enabled) {
+            List<String> headerValues = attributes.get(HEADER_ATTRIBUTE_KEY);
+            if (headerValues != null && headerValues.stream().anyMatch(Boolean::parseBoolean)) {
+                return SamplingResult.recordAndSample();
+            }
+        }
+
+        return delegate.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+    }
+
+    @Override
+    public String getDescription() {
+        return "ForcedTracingSampler{" + delegate.getDescription() + "}";
+    }
+}

--- a/src/main/java/com/monta/otel/extension/ResponseHeaderCustomizer.java
+++ b/src/main/java/com/monta/otel/extension/ResponseHeaderCustomizer.java
@@ -19,7 +19,7 @@ public class ResponseHeaderCustomizer implements HttpServerResponseCustomizer {
 
     private static final String TRACE_ID_HEADER = "Trace-Id";
     private static final String ENABLED_ENV_VAR = "OTEL_RESPONSE_HEADERS_ENABLED";
-    private static final boolean ENABLED = "true".equalsIgnoreCase(System.getenv(ENABLED_ENV_VAR));
+    private static final boolean ENABLED = Boolean.parseBoolean(System.getenv(ENABLED_ENV_VAR));
 
     @Override
     public <RESPONSE> void customize(

--- a/src/test/java/com/monta/otel/extension/ForcedTracingSamplerTest.java
+++ b/src/test/java/com/monta/otel/extension/ForcedTracingSamplerTest.java
@@ -1,0 +1,88 @@
+package com.monta.otel.extension;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ForcedTracingSamplerTest {
+
+    private static final String TRACE_ID = "00000000000000000000000000000001";
+
+    private SamplingResult sample(ForcedTracingSampler sampler, Attributes attributes) {
+        return sampler.shouldSample(
+                Context.root(),
+                TRACE_ID,
+                "test-span",
+                SpanKind.SERVER,
+                attributes,
+                Collections.emptyList()
+        );
+    }
+
+    @Test
+    void forcesRecordAndSampleWhenHeaderIsTrueAndEnabled() {
+        ForcedTracingSampler sampler = new ForcedTracingSampler(Sampler.alwaysOff(), true);
+
+        Attributes attributes = Attributes.of(
+                ForcedTracingSampler.HEADER_ATTRIBUTE_KEY, List.of("true")
+        );
+
+        assertEquals(SamplingDecision.RECORD_AND_SAMPLE, sample(sampler, attributes).getDecision());
+    }
+
+    @Test
+    void forcesRecordAndSampleWhenHeaderIsTrueCaseInsensitiveAndEnabled() {
+        ForcedTracingSampler sampler = new ForcedTracingSampler(Sampler.alwaysOff(), true);
+
+        Attributes attributes = Attributes.of(
+                ForcedTracingSampler.HEADER_ATTRIBUTE_KEY, List.of("TRUE")
+        );
+
+        assertEquals(SamplingDecision.RECORD_AND_SAMPLE, sample(sampler, attributes).getDecision());
+    }
+
+    @Test
+    void delegatesToWrappedSamplerWhenHeaderIsAbsent() {
+        ForcedTracingSampler sampler = new ForcedTracingSampler(Sampler.alwaysOff(), true);
+
+        assertEquals(SamplingDecision.DROP, sample(sampler, Attributes.empty()).getDecision());
+    }
+
+    @Test
+    void delegatesToWrappedSamplerWhenHeaderValueIsNotRecognised() {
+        ForcedTracingSampler sampler = new ForcedTracingSampler(Sampler.alwaysOff(), true);
+
+        Attributes attributes = Attributes.of(
+                ForcedTracingSampler.HEADER_ATTRIBUTE_KEY, List.of("yes")
+        );
+
+        assertEquals(SamplingDecision.DROP, sample(sampler, attributes).getDecision());
+    }
+
+    @Test
+    void delegatesToWrappedSamplerWhenDisabledEvenIfHeaderIsPresent() {
+        ForcedTracingSampler sampler = new ForcedTracingSampler(Sampler.alwaysOff(), false);
+
+        Attributes attributes = Attributes.of(
+                ForcedTracingSampler.HEADER_ATTRIBUTE_KEY, List.of("true")
+        );
+
+        assertEquals(SamplingDecision.DROP, sample(sampler, attributes).getDecision());
+    }
+
+    @Test
+    void descriptionIncludesDelegateDescription() {
+        ForcedTracingSampler sampler = new ForcedTracingSampler(Sampler.alwaysOn(), true);
+
+        assertEquals("ForcedTracingSampler{AlwaysOnSampler}", sampler.getDescription());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ForcedTracingSampler` wrapping the existing sampler chain — when `Force-Trace: true` is sent on a request, the span is always recorded and sampled, bypassing rate limits and drop rules
- Enabled via `OTEL_FORCE_TRACE_HEADER_ENABLED=true`, disabled by default
- The `Force-Trace` header is captured as span attribute `http.request.header.force-trace` by the OTel Java agent's built-in HTTP instrumentation, configured via `otel.instrumentation.http.server.request.captured.headers` (set in `Customizer` using `addPropertiesSupplier`). The OTel agent extracts request headers in `AttributesExtractor.onStart()` before `shouldSample()` is called, so the attribute is available to the sampler at head-sampling time.
- Since we use tail-based sampling (Alloy), the head sampler alone is not enough — a companion PR [kube-manifests#6184](https://github.com/monta-app/kube-manifests/pull/6184) adds a `forced_tracing_header` OTTL policy to the Alloy tail sampler in all clusters, keeping any trace where the attribute is present