### PR TITLE
chore: Upgrade OTEL from 2.26.1 to 2.29.0 [NOJIRA]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("com.gradleup.shadow") version "9.4.1"
+    id("com.gradleup.shadow") version "9.5.1"
 }
 
 version = "1.0.0"
@@ -12,15 +12,15 @@ repositories {
 }
 
 dependencies {
-    val otelVersion = "2.26.1"
+    val otelVersion = "2.29.0"
     implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelVersion-alpha"))
     implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
     implementation("io.opentelemetry.semconv:opentelemetry-semconv")
-    implementation("io.opentelemetry.contrib:opentelemetry-samplers:1.54.0-alpha")
+    implementation("io.opentelemetry.contrib:opentelemetry-samplers:1.58.0-alpha")
     // Dependency for HTTP response header customization
     implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
 
-    testImplementation("org.junit.jupiter:junit-jupiter:6.0.3")
+    testImplementation("org.junit.jupiter:junit-jupiter:6.1.1")
     testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }


### PR DESCRIPTION
* this upgrades the API from 1.60.0 to 1.63.0 which fixes [CVE-2026-45292](https://avd.aquasec.com/nvd/2026/cve-2026-45292/)
* release notes [2.29.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.29.0) this targets the API 1.63
* updates the java contrib samplers to [1.58.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.58.0) which also targets 2.29.0