### PR TITLE
chore(deps): bump otel-instrumentation to 2.30.0-alpha to enable v2.30.0 release [NOJIRA]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 shadow = "9.6.0"
-otel-instrumentation = "2.29.0-alpha"
+otel-instrumentation = "2.30.0-alpha"
 otel-contrib-samplers = "1.58.0-alpha"
 junit = "6.1.2"
 


### PR DESCRIPTION
## What

Bump `otel-instrumentation` 2.29.0-alpha → **2.30.0-alpha** in `gradle/libs.versions.toml`, so a **v2.30.0** release can be cut.

## Why

The image scanner flags jackson-databind CVE-2026-54512 / CVE-2026-54513 and jackson-core GHSA-r7wm-3cxj-wff9 across ~9 Kotlin services. The vulnerable jackson isn't in those apps — it's **bundled inside the OpenTelemetry javaagent** they `ADD` into their images. A gradle `resolutionStrategy` pin can't touch a jar bundled inside the agent, so the only fix is a newer agent.

Per-agent bundled jackson (databind and core move together):

| javaagent | jackson | clears the finding? |
|-----------|:---:|:--:|
| 2.6.0 | 2.17.2 | no |
| 2.26.1 (current newest ext release) | 2.21.1 | no (< 2.21.4) |
| 2.29.0 | 2.22.0 | databind yes, **core GHSA-r7wm-3cxj-wff9 no** (fixed only in 2.22.1) |
| **2.30.0** | **2.22.1** | **yes — all of them** |

So services need `OTEL_VERSION=2.30.0`, and this repo must have a **v2.30.0** release so their Dockerfile `ADD` of the extension resolves. (Most services pull the agent and this extension at the same `OTEL_VERSION`; a couple pin `OTEL_EXTENSION_VERSION` separately — those will be re-aligned to v2.30.0 in the service bumps, since agent and extension must match at runtime, see below.)

## Validation

Verified three ways (local, JDK 25):

1. **The version genuinely clears it.** Trivy on the standalone `jackson-core-2.22.1.jar` and `jackson-databind-2.22.1.jar` (what agent 2.30.0 bundles) → **0 vulnerabilities**; 54512, 54513, 54515, 59888/59889, and GHSA-r7wm-3cxj-wff9 all gone. 2.30.0 is the minimum — 2.29.0's jackson 2.22.0 still reports the jackson-core HIGH. (Note: scanning the raw agent jar is a false-negative — it ships jackson as shaded classdata with no `pom.properties` — so the evidence is the standalone-jar scan of the bundled version.)
2. **This extension builds + tests clean at 2.30.0-alpha** (`./gradlew clean shadowJar test` green), and the built `otel-extension.jar` contains **no jackson** (adds no copy of its own).
3. **The rebuilt extension loads and runs at runtime inside the v2.30.0 agent** — its `AutoConfigurationCustomizerProvider` is discovered and `Customizer.customize()` executes (its resource attributes appear in an exported span only when registered), with zero `ServiceConfigurationError` / `AbstractMethodError` / linkage errors. Negative control: the same jar under the old 2.6.0 agent fails with `ServiceConfigurationError`, confirming the check is real and that extension/agent versions must match.

`otel-contrib-samplers` (1.58.0-alpha) is left unchanged — it builds and tests clean against the 2.30.0-alpha BOM.

## Release

This repo publishes on a `v*` tag push (`publish.yml`). After merge, tag **v2.30.0** to publish the extension binary so the downstream `OTEL_VERSION=2.30.0` service bumps can build.
